### PR TITLE
feat: 배포 환경에서 MySql 연결을 위한 properties 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,10 @@
+spring.datasource.url=jdbc:h2:mem:time-tracker;MODE=MySQL;DATABASE_TO_UPPER=false;NON_KEYWORDS=VALUE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+spring.jpa.hibernate.ddl-auto=create-drop
+
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:mysql://${MYSQLHOST}:${MYSQLPORT}/${MYSQLDATABASE}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+spring.datasource.username=${MYSQLUSER}
+spring.datasource.password=${MYSQLPASSWORD}
+
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -2,5 +2,4 @@ spring.datasource.url=jdbc:mysql://${MYSQLHOST}:${MYSQLPORT}/${MYSQLDATABASE}?us
 spring.datasource.username=${MYSQLUSER}
 spring.datasource.password=${MYSQLPASSWORD}
 
-spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=time-tracker
+
+spring.profiles.default=dev
+
+server.port=${PORT:8080}
+
+spring.jpa.open-in-view=false
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
### 기능 구현 사항
1. 프로파일 분리: `dev`(H2) / `prod`(MySQL)
2. 공통 설정 추가: 
    - `spring.profiles.default=dev`
    - `server.port=${PORT:8080}`
    - `spring.jpa.open-in-view=false`
    - `hibernate.format_sql=true`
3. `application-dev.properties`: H2 in-memory(DB) 구성 및 `/h2-console` 활성화
4. `application-prod.properties`: MySQL 연결, `ddl-auto=update`
5. 빌드 설정: `mysql-connector-j` 런타임 의존성 추가