### PR TITLE
feat: 활동 기록(Activity Record) 추가/삭제 기능 구현

### DIFF
--- a/src/main/java/org/project/timetracker/auth/TokenProcessor.java
+++ b/src/main/java/org/project/timetracker/auth/TokenProcessor.java
@@ -46,7 +46,7 @@ public final class TokenProcessor {
         return generateToken(userId, accessExpiredTime);
     }
 
-    private Long parseToken(String token) {
+    public Long parseToken(String token) {
         Claims payload = Jwts.parser()
                 .verifyWith(secretKey)
                 .build()

--- a/src/main/java/org/project/timetracker/global/ExceptionResponse.java
+++ b/src/main/java/org/project/timetracker/global/ExceptionResponse.java
@@ -1,9 +1,11 @@
 package org.project.timetracker.global;
 
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public class ExceptionResponse {
 
     private final Boolean success = false;

--- a/src/main/java/org/project/timetracker/global/GlobalExceptionController.java
+++ b/src/main/java/org/project/timetracker/global/GlobalExceptionController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
-public class ExceptionController {
+public class GlobalExceptionController {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ExceptionResponse> handleAllCustom(IllegalArgumentException e) {

--- a/src/main/java/org/project/timetracker/record/ActivityRecord.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecord.java
@@ -1,0 +1,65 @@
+package org.project.timetracker.record;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.project.timetracker.auth.User;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActivityRecord {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(nullable = false)
+    private LocalDateTime endTime;
+
+    @Column(nullable = false)
+    private String category;
+
+    private String memo;
+
+    @Builder
+    public ActivityRecord(User user, LocalDateTime startTime, LocalDateTime endTime, String category, String memo) {
+        this.user = user;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.category = category;
+        this.memo = memo;
+    }
+
+    public static ActivityRecord create(User user, LocalDateTime startTime, LocalDateTime endTime, String category, String memo) {
+        String memoToSave = memo;
+        if (memoToSave == null) {
+            memoToSave = "";
+        }
+
+        return ActivityRecord.builder()
+                .user(user)
+                .startTime(startTime)
+                .endTime(endTime)
+                .category(category)
+                .memo(memoToSave)
+                .build();
+    }
+
+}

--- a/src/main/java/org/project/timetracker/record/ActivityRecordController.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordController.java
@@ -19,4 +19,10 @@ public class ActivityRecordController {
         ActivityRecordResponse response = activityRecordService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
+
+    @PostMapping("/delete")
+    public ResponseEntity<ActivityRecordResponse> delete(@RequestBody ActivityRecordDeleteRequest request) {
+        ActivityRecordResponse response = activityRecordService.deleteSchedule(request);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/org/project/timetracker/record/ActivityRecordController.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordController.java
@@ -1,0 +1,22 @@
+package org.project.timetracker.record;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/records")
+@RequiredArgsConstructor
+public class ActivityRecordController {
+    private final ActivityRecordService activityRecordService;
+
+    @PostMapping
+    public ResponseEntity<ActivityRecordResponse> create(@RequestBody ActivityRecordCreateRequest request) {
+        ActivityRecordResponse response = activityRecordService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/org/project/timetracker/record/ActivityRecordCreateRequest.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordCreateRequest.java
@@ -1,0 +1,11 @@
+package org.project.timetracker.record;
+
+public record ActivityRecordCreateRequest(
+        String token,
+        String date,
+        String startTime,
+        String endTime,
+        String category,
+        String memo
+) {
+}

--- a/src/main/java/org/project/timetracker/record/ActivityRecordDeleteRequest.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordDeleteRequest.java
@@ -1,0 +1,8 @@
+package org.project.timetracker.record;
+
+public record ActivityRecordDeleteRequest(
+        String token,
+        String date,
+        String startTime
+) {
+}

--- a/src/main/java/org/project/timetracker/record/ActivityRecordRepository.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordRepository.java
@@ -1,0 +1,15 @@
+package org.project.timetracker.record;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ActivityRecordRepository extends JpaRepository<ActivityRecord, Long> {
+    List<ActivityRecord> findByUserIdAndStartTimeBetweenOrderByStartTimeAsc(Long userId, LocalDateTime start, LocalDateTime end);
+
+    @Query("SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END FROM ActivityRecord r WHERE r.user.id = :userId AND r.startTime < :newEndTime AND r.endTime > :newStartTime")
+    boolean existsOverlappingRecords(@Param("userId") Long userId, @Param("newStartTime") LocalDateTime newStartTime, @Param("newEndTime") LocalDateTime newEndTime);
+}

--- a/src/main/java/org/project/timetracker/record/ActivityRecordRepository.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.repository.query.Param;
 public interface ActivityRecordRepository extends JpaRepository<ActivityRecord, Long> {
     List<ActivityRecord> findByUserIdAndStartTimeBetweenOrderByStartTimeAsc(Long userId, LocalDateTime start, LocalDateTime end);
 
+    Optional<ActivityRecord> findByUserIdAndStartTime(Long userId, LocalDateTime startTime);
+
     @Query("SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END FROM ActivityRecord r WHERE r.user.id = :userId AND r.startTime < :newEndTime AND r.endTime > :newStartTime")
     boolean existsOverlappingRecords(@Param("userId") Long userId, @Param("newStartTime") LocalDateTime newStartTime, @Param("newEndTime") LocalDateTime newEndTime);
 }

--- a/src/main/java/org/project/timetracker/record/ActivityRecordResponse.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordResponse.java
@@ -1,0 +1,16 @@
+package org.project.timetracker.record;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.project.timetracker.record.data.ActivityRecordMonthData;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ActivityRecordResponse(
+        boolean success,
+        String message,
+        ActivityRecordMonthData data
+) {
+    public static ActivityRecordResponse success(String message, ActivityRecordMonthData data) {
+        return new ActivityRecordResponse(true, message, data);
+    }
+}

--- a/src/main/java/org/project/timetracker/record/ActivityRecordService.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordService.java
@@ -50,6 +50,19 @@ public class ActivityRecordService {
         return buildMonthlyResponse(userId, request.date().substring(0, 6), "일정이 성공적으로 추가되었습니다.");
     }
 
+    public ActivityRecordResponse deleteSchedule(ActivityRecordDeleteRequest request) {
+        Long userId = tokenProcessor.parseToken(request.token());
+        LocalDateTime startTime = parseDateTime(request.date(), request.startTime());
+
+        ActivityRecord recordToDelete = activityRecordRepository.findByUserIdAndStartTime(userId, startTime)
+                .orElseThrow(() -> new IllegalArgumentException("해당 시간대 일정이 없습니다."));
+
+        String yearMonth = recordToDelete.getStartTime().format(DateTimeFormatter.ofPattern("yyyyMM"));
+        activityRecordRepository.delete(recordToDelete);
+
+        return buildMonthlyResponse(userId, yearMonth, "ok");
+    }
+
     private ActivityRecordResponse buildMonthlyResponse(Long userId, String yearMonthStr, String message) {
         YearMonth yearMonth = YearMonth.parse(yearMonthStr, DateTimeFormatter.ofPattern("yyyyMM"));
         LocalDate startDate = yearMonth.atDay(1);

--- a/src/main/java/org/project/timetracker/record/ActivityRecordService.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordService.java
@@ -1,0 +1,96 @@
+package org.project.timetracker.record;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.project.timetracker.auth.TokenProcessor;
+import org.project.timetracker.auth.User;
+import org.project.timetracker.auth.UserRepository;
+import org.project.timetracker.record.data.ActivityRecordDayData;
+import org.project.timetracker.record.data.ActivityRecordEntry;
+import org.project.timetracker.record.data.ActivityRecordMonthData;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ActivityRecordService {
+
+    private final ActivityRecordRepository activityRecordRepository;
+    private final UserRepository userRepository;
+    private final TokenProcessor tokenProcessor;
+
+    public ActivityRecordResponse create(ActivityRecordCreateRequest request) {
+        Long userId = tokenProcessor.parseToken(request.token());
+        User user = findUserById(userId);
+
+        LocalDateTime startTime = parseDateTime(request.date(), request.startTime());
+        LocalDateTime endTime = parseDateTime(request.date(), request.endTime());
+
+        if (activityRecordRepository.existsOverlappingRecords(userId, startTime, endTime)) {
+            throw new IllegalArgumentException("이미 해당 시간대에 일정이 존재합니다.");
+        }
+
+        ActivityRecord newRecord = ActivityRecord.create(
+                user,
+                startTime,
+                endTime,
+                request.category(),
+                request.memo());
+
+        activityRecordRepository.save(newRecord);
+
+        return buildMonthlyResponse(userId, request.date().substring(0, 6), "일정이 성공적으로 추가되었습니다.");
+    }
+
+    private ActivityRecordResponse buildMonthlyResponse(Long userId, String yearMonthStr, String message) {
+        YearMonth yearMonth = YearMonth.parse(yearMonthStr, DateTimeFormatter.ofPattern("yyyyMM"));
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        List<ActivityRecord> records = activityRecordRepository.findByUserIdAndStartTimeBetweenOrderByStartTimeAsc(userId, startDate.atStartOfDay(), endDate.plusDays(1).atStartOfDay());
+        Map<LocalDate, List<ActivityRecord>> recordsByDate = records.stream()
+                .collect(Collectors.groupingBy(
+                        r -> r.getStartTime().toLocalDate()));
+
+        List<ActivityRecordDayData> days = recordsByDate.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> {
+                    LocalDate date = entry.getKey();
+                    List<ActivityRecord> dailyRecords = entry.getValue();
+
+                    List<ActivityRecordEntry> entries = dailyRecords.stream()
+                            .map(r -> new ActivityRecordEntry(
+                                    r.getStartTime().toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm")),
+                                    r.getEndTime().toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm")),
+                                    r.getMemo()
+                            )).collect(Collectors.toList());
+
+                    return new ActivityRecordDayData(
+                            date.format(DateTimeFormatter.ISO_LOCAL_DATE),
+                            date.getDayOfMonth(),
+                            date.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN),
+                            entries
+                    );
+                }).collect(Collectors.toList());
+
+        ActivityRecordMonthData monthData = new ActivityRecordMonthData(yearMonthStr, days);
+        return ActivityRecordResponse.success(message, monthData);
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+    }
+
+    private LocalDateTime parseDateTime(String date, String time) {
+        return LocalDateTime.of(LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyyMMdd")),
+                LocalTime.parse(time, DateTimeFormatter.ofPattern("HH:mm")));
+    }
+}

--- a/src/main/java/org/project/timetracker/record/data/ActivityRecordDayData.java
+++ b/src/main/java/org/project/timetracker/record/data/ActivityRecordDayData.java
@@ -1,0 +1,12 @@
+package org.project.timetracker.record.data;
+
+import java.util.List;
+
+public record ActivityRecordDayData(
+        String date,
+        int day,
+        String weekday,
+        List<ActivityRecordEntry> entries
+) {
+
+}

--- a/src/main/java/org/project/timetracker/record/data/ActivityRecordEntry.java
+++ b/src/main/java/org/project/timetracker/record/data/ActivityRecordEntry.java
@@ -1,0 +1,9 @@
+package org.project.timetracker.record.data;
+
+public record ActivityRecordEntry(
+        String start,
+        String end,
+        String label
+) {
+
+}

--- a/src/main/java/org/project/timetracker/record/data/ActivityRecordMonthData.java
+++ b/src/main/java/org/project/timetracker/record/data/ActivityRecordMonthData.java
@@ -1,0 +1,10 @@
+package org.project.timetracker.record.data;
+
+import java.util.List;
+
+public record ActivityRecordMonthData(
+        String month,
+        List<ActivityRecordDayData> days
+) {
+
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -6,7 +6,7 @@ spring.datasource.username=sa
 spring.datasource.password=
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=update
 
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console


### PR DESCRIPTION
### 주요 변경 사항
1. 활동 기록 엔티티 및 DTO 설계
    - ActivityRecord 엔티티를 구현하여 사용자의 활동 데이터를 저장할 수 있는 기반을 마련

    - 프론트엔드 캘린더 화면에 필요한 JSON 응답 구조에 맞춰 ActivityRecordResponse, ActivityRecordMonthData 등 관련 DTO 4종 추가

2. 활동 기록 생성 및 삭제 기능 구현
    - 기록 생성: 사용자가 새로운 일정을 등록하고 반영된 월별 데이터를 응답으로 반환하는 API(POST /api/records)를 구현

        - 중복된 시간에 일정이 등록되지 않도록 예외 처리 로직 포함

    - 기록 삭제: 사용자가 특정 일정을 삭제하고 반영된 월별 데이터를 응답으로 반환하는 API(POST /api/records/delete)를 구현했습니다.
        - 요청 시간대에 데이터가 없을 경우에 대한 예외 처리 로직 포함 
 ### 코멘트
1. 로그인 어노테이션이 없다보니 임시적으로 TokenProcessor의 parseToken을 public으로 변경하였습니다.
2. ActivityRecord 가 추가되면서 ddl-auto : create-drop 이 문제를 발생시켜서 update로 변경하였습니다. create-drop을 꼭 써야하는 상황이 온다면 다른 해결방법 찾아보겠습니다.