### PR TITLE
feat: 이메일 중복 검사 API 구현

### DIFF
--- a/src/main/java/org/project/timetracker/auth/AuthController.java
+++ b/src/main/java/org/project/timetracker/auth/AuthController.java
@@ -40,4 +40,15 @@ public class AuthController {
             throw new IllegalArgumentException("회원가입 실패", e);
         }
     }
+
+    @PostMapping("/duplicate-check")
+    public ResponseEntity<DuplicateCheckResponse> duplicateCheck(@RequestBody DuplicateCheckRequest request) {
+        boolean isDuplicate = userRepository.existsByLoginId(request.email());
+
+        if (isDuplicate) {
+            return ResponseEntity.ok().body(DuplicateCheckResponse.ofFail());
+        } else {
+            return ResponseEntity.ok().body(DuplicateCheckResponse.ofSuccess());
+        }
+    }
 }

--- a/src/main/java/org/project/timetracker/auth/DuplicateCheckRequest.java
+++ b/src/main/java/org/project/timetracker/auth/DuplicateCheckRequest.java
@@ -1,0 +1,7 @@
+package org.project.timetracker.auth;
+
+public record DuplicateCheckRequest(
+        String email
+) {
+
+}

--- a/src/main/java/org/project/timetracker/auth/DuplicateCheckResponse.java
+++ b/src/main/java/org/project/timetracker/auth/DuplicateCheckResponse.java
@@ -1,0 +1,14 @@
+package org.project.timetracker.auth;
+
+public record DuplicateCheckResponse(
+        boolean success,
+        String message
+) {
+    public static DuplicateCheckResponse ofFail() {
+        return new DuplicateCheckResponse(false, "이미 사용 중인 아이디입니다.");
+    }
+
+    public static DuplicateCheckResponse ofSuccess() {
+        return new DuplicateCheckResponse(true, "사용 가능한 아이디입니다.");
+    }
+}

--- a/src/main/java/org/project/timetracker/auth/RegisterResponse.java
+++ b/src/main/java/org/project/timetracker/auth/RegisterResponse.java
@@ -1,8 +1,10 @@
 package org.project.timetracker.auth;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public class RegisterResponse {
 
     private final Boolean success;


### PR DESCRIPTION
### 주요 변경 사항
1. API 추가: POST /duplicate-check

   - DTO 구현: 요청/응답 데이터 처리를 위해 DuplicateCheckRequest, DuplicateCheckResponse를 Java Record를 사용하여 불변 객체로 구현
   - API 응답: 중복 여부와 관계없이 중복 확인 요청 자체는 성공한 것으로 간주하여 HTTP 상태 코드는 항상 200 OK로 응답하고 본문의 success 필드로 결과를 구분하도록 설계

### 코멘트
RegisterResponse에 `@Getter` 빠져있어서 이 부분 추가해줬습니다.