### PR TITLE
feat: 활동기록을 통계내는 api 구현

### DIFF
--- a/src/main/java/org/project/timetracker/record/ActivityRecord.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecord.java
@@ -1,19 +1,14 @@
 package org.project.timetracker.record;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import java.time.LocalDateTime;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.project.timetracker.auth.User;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -60,6 +55,11 @@ public class ActivityRecord {
                 .category(category)
                 .memo(memoToSave)
                 .build();
+    }
+
+    public long getSpanMinutes() {
+        Duration span = Duration.between(startTime, endTime);
+        return span.toMinutes();
     }
 
 }

--- a/src/main/java/org/project/timetracker/record/ActivityRecordRepository.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordRepository.java
@@ -14,4 +14,8 @@ public interface ActivityRecordRepository extends JpaRepository<ActivityRecord, 
 
     @Query("SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END FROM ActivityRecord r WHERE r.user.id = :userId AND r.startTime < :newEndTime AND r.endTime > :newStartTime")
     boolean existsOverlappingRecords(@Param("userId") Long userId, @Param("newStartTime") LocalDateTime newStartTime, @Param("newEndTime") LocalDateTime newEndTime);
+
+    @Query("select ar from ActivityRecord ar where ar.user.id= :userId and ar.startTime >= :start and ar.endTime <= :end")
+    List<ActivityRecord> findByUserIdAndBetweenTime(Long userId, LocalDateTime start, LocalDateTime end);
+
 }

--- a/src/main/java/org/project/timetracker/statistic/StatistcsData.java
+++ b/src/main/java/org/project/timetracker/statistic/StatistcsData.java
@@ -1,0 +1,20 @@
+package org.project.timetracker.statistic;
+
+public class StatistcsData {
+
+    private int frequency;
+    private long amount;
+
+    public StatistcsData(int frequency, long amount) {
+        this.frequency = frequency;
+        this.amount = amount;
+    }
+
+    public int getFrequency() {
+        return frequency;
+    }
+
+    public long getAmount() {
+        return amount;
+    }
+}

--- a/src/main/java/org/project/timetracker/statistic/StatisticsController.java
+++ b/src/main/java/org/project/timetracker/statistic/StatisticsController.java
@@ -1,0 +1,97 @@
+package org.project.timetracker.statistic;
+
+import lombok.RequiredArgsConstructor;
+import org.project.timetracker.auth.TokenProcessor;
+import org.project.timetracker.auth.User;
+import org.project.timetracker.auth.UserRepository;
+import org.project.timetracker.record.ActivityRecord;
+import org.project.timetracker.record.ActivityRecordRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+public class StatisticsController {
+
+    private final TokenProcessor tokenProcessor;
+    private final UserRepository userRepository;
+    private final ActivityRecordRepository activityRecordRepository;
+
+    @GetMapping("/api/statistics")
+    public ResponseEntity<StatisticsResponse> getStatistics(@RequestBody StatisticsRequest request) {
+        Long userId = tokenProcessor.parseToken(request.getToken());
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        LocalDateTime startDate = LocalDateTime.from(LocalDate.parse(request.getStartDate(), DateTimeFormatter.ofPattern("yyyyMMdd")));
+        LocalDateTime endDate = LocalDateTime.from(LocalDate.parse(request.getEndDate(), DateTimeFormatter.ofPattern("yyyyMMdd")));
+        long timeTotal = Duration.between(startDate, endDate).toMinutes();
+
+        List<ActivityRecord> activityRecords = activityRecordRepository.findByUserIdAndBetweenTime(user.getId(), startDate, endDate);
+
+        Map<String, List<ActivityRecord>> groupBy = activityRecords.stream().collect(Collectors.groupingBy(ActivityRecord::getCategory));
+
+
+        Map<String, StatistcsData> miniResults = getStatisticsByCategory(groupBy);
+
+        long amountTotal = miniResults.values().stream()
+                .mapToLong(StatistcsData::getAmount)
+                .sum();
+
+        List<StatisticsDataResponse> dataResponse = getTotalStatistics(miniResults, amountTotal, timeTotal);
+
+        return  ResponseEntity.ok(new StatisticsResponse(dataResponse));
+
+    }
+
+    private List<StatisticsDataResponse> getTotalStatistics(Map<String, StatistcsData> miniResults, long amountTotal, long timeTotal) {
+        List<StatisticsDataResponse> dataResponse = new ArrayList<>();
+
+        for (Map.Entry<String, StatistcsData> miniResult : miniResults.entrySet()) {
+            String category = miniResult.getKey();
+            StatistcsData activityRecordValue = miniResult.getValue();
+
+            long amount = activityRecordValue.getAmount();
+
+            long hours = amount / 60;
+            long minutes = amount % 60;
+
+            String formattedAmount = String.format("%02d:%02d", hours, minutes);
+
+            long timePercent = Math.round((float) amount / amountTotal * 100);
+            long accordPercent = Math.round((float) amount / timeTotal * 100);
+
+
+            dataResponse.add(new StatisticsDataResponse(category, activityRecordValue.getFrequency(), formattedAmount, timePercent, accordPercent));
+        }
+        return dataResponse;
+    }
+
+    private Map<String, StatistcsData> getStatisticsByCategory(Map<String, List<ActivityRecord>> groupBy) {
+        Map<String, StatistcsData> results = new HashMap<>();
+        for (Map.Entry<String, List<ActivityRecord>> maps : groupBy.entrySet()) {
+            String category = maps.getKey();
+            List<ActivityRecord> records = maps.getValue();
+            int frequency = records.size();
+            long amount = records.stream().mapToLong(ActivityRecord::getSpanMinutes)
+                    .sum();
+            results.put(category, new StatistcsData(frequency, amount));
+        }
+        return results;
+    }
+}
+
+

--- a/src/main/java/org/project/timetracker/statistic/StatisticsDataResponse.java
+++ b/src/main/java/org/project/timetracker/statistic/StatisticsDataResponse.java
@@ -1,0 +1,21 @@
+package org.project.timetracker.statistic;
+
+import lombok.Getter;
+
+@Getter
+public class StatisticsDataResponse {
+
+    private String category;
+    private int frequency;
+    private String amount;
+    private double timePercent;
+    private double accordPercent;
+
+    public StatisticsDataResponse(String category, int frequency, String amount, double timePercent, double accordPercent) {
+        this.category = category;
+        this.frequency = frequency;
+        this.amount = amount;
+        this.timePercent = timePercent;
+        this.accordPercent = accordPercent;
+    }
+}

--- a/src/main/java/org/project/timetracker/statistic/StatisticsRequest.java
+++ b/src/main/java/org/project/timetracker/statistic/StatisticsRequest.java
@@ -1,0 +1,19 @@
+package org.project.timetracker.statistic;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class StatisticsRequest {
+
+    private String token;
+    private String startDate;
+    private String endDate;
+
+    public StatisticsRequest(String token, String startDate, String endDate) {
+        this.token = token;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+}

--- a/src/main/java/org/project/timetracker/statistic/StatisticsResponse.java
+++ b/src/main/java/org/project/timetracker/statistic/StatisticsResponse.java
@@ -1,0 +1,19 @@
+package org.project.timetracker.statistic;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+public class StatisticsResponse {
+
+    private Boolean success = true;
+    private String message = "기록이 성공적으로 조회 되었습니다.";
+    private List<StatisticsDataResponse> data;
+
+    public StatisticsResponse(List<StatisticsDataResponse> dataResponse) {
+        this.data = dataResponse;
+    }
+}


### PR DESCRIPTION
## 주요 변경 사항
- 요청값으로 기간을 받아서  해당 기간내에 존재하는 활동기록들을 조회해서 통계내는 작업의 api를 구현했습니다.
- 기간내 존재하는 활동기록을 조회해 빈도수, 총 시간, 기간에 따른 비율, 다른 기록간의 비율을 계산하여 응답합니다.
