### PR TITLE
refactor: 기록 생성 시 응답으로 전체 데이터를 반환하도록 수정

### DIFF
--- a/src/main/java/org/project/timetracker/record/ActivityRecordDtoMapper.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordDtoMapper.java
@@ -1,0 +1,69 @@
+package org.project.timetracker.record;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.project.timetracker.record.data.ActivityRecordAllData;
+import org.project.timetracker.record.data.ActivityRecordDayData;
+import org.project.timetracker.record.data.ActivityRecordEntry;
+import org.project.timetracker.record.data.ActivityRecordMonthData;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ActivityRecordDtoMapper {
+    //ActivityRecordAllData 반환 메서드(최종)
+    public ActivityRecordAllData mapToAllData(List<ActivityRecord> allRecords) {
+        Map<YearMonth, Map<LocalDate, List<ActivityRecord>>> recordsByYearMonthAndDay = groupRecordsByYearMonthAndDay(allRecords);
+        List<ActivityRecordMonthData> monthDataList = mapToMonthDataList(recordsByYearMonthAndDay);
+        return new ActivityRecordAllData(monthDataList);
+    }
+
+    private Map<YearMonth, Map<LocalDate, List<ActivityRecord>>> groupRecordsByYearMonthAndDay(List<ActivityRecord> allRecords) {
+        return allRecords.stream()
+                .collect(Collectors.groupingBy(
+                        record -> YearMonth.from(record.getStartTime()),
+                        LinkedHashMap::new,
+                        Collectors.groupingBy(
+                                record -> record.getStartTime().toLocalDate(),
+                                LinkedHashMap::new,
+                                Collectors.toList()
+                        )
+                ));
+    }
+
+    //YearMonth - LocalDate, List<ActivityRecord> --> List<ActivityRecordMonthData> 변환 메서드
+    private List<ActivityRecordMonthData> mapToMonthDataList(Map<YearMonth, Map<LocalDate, List<ActivityRecord>>> monthMap) {
+        return monthMap.entrySet().stream()
+                .map(monthEntry -> {
+                    YearMonth yearMonth = monthEntry.getKey();
+                    Map<LocalDate, List<ActivityRecord>> dailyMap = monthEntry.getValue();
+                    List<ActivityRecordDayData> dayDataList = mapToDayDataList(dailyMap);
+
+                    return ActivityRecordMonthData.from(yearMonth, dayDataList);
+                })
+                .toList();
+    }
+
+    //LocalDate, List<ActivityRecord> --> List<ActivityRecordDayData> 변환 메서드
+    private List<ActivityRecordDayData> mapToDayDataList(Map<LocalDate, List<ActivityRecord>> dailyMap) {
+        return dailyMap.entrySet().stream()
+                .map(dayEntry -> {
+                    LocalDate date = dayEntry.getKey();
+                    List<ActivityRecord> dailyRecords = dayEntry.getValue();
+                    List<ActivityRecordEntry> entries = mapToEntryList(dailyRecords);
+
+                    return ActivityRecordDayData.from(date, entries);
+                })
+                .toList();
+    }
+
+    //List<ActivityRecord> --> List<ActivityRecordEntry> 변환 메서드
+    private List<ActivityRecordEntry> mapToEntryList(List<ActivityRecord> activityRecords) {
+        return activityRecords.stream()
+                .map(ActivityRecordEntry::from)
+                .toList();
+    }
+}

--- a/src/main/java/org/project/timetracker/record/ActivityRecordRepository.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordRepository.java
@@ -8,10 +8,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ActivityRecordRepository extends JpaRepository<ActivityRecord, Long> {
-    List<ActivityRecord> findByUserIdAndStartTimeBetweenOrderByStartTimeAsc(Long userId, LocalDateTime start, LocalDateTime end);
-
     Optional<ActivityRecord> findByUserIdAndStartTime(Long userId, LocalDateTime startTime);
 
     @Query("SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END FROM ActivityRecord r WHERE r.user.id = :userId AND r.startTime < :newEndTime AND r.endTime > :newStartTime")
     boolean existsOverlappingRecords(@Param("userId") Long userId, @Param("newStartTime") LocalDateTime newStartTime, @Param("newEndTime") LocalDateTime newEndTime);
+
+    List<ActivityRecord> findByUserIdOrderByStartTimeAsc(Long userId);
 }

--- a/src/main/java/org/project/timetracker/record/ActivityRecordResponse.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordResponse.java
@@ -2,15 +2,16 @@ package org.project.timetracker.record;
 
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.project.timetracker.record.data.ActivityRecordAllData;
 import org.project.timetracker.record.data.ActivityRecordMonthData;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ActivityRecordResponse(
         boolean success,
         String message,
-        ActivityRecordMonthData data
+        ActivityRecordAllData data
 ) {
-    public static ActivityRecordResponse success(String message, ActivityRecordMonthData data) {
+    public static ActivityRecordResponse success(String message, ActivityRecordAllData data) {
         return new ActivityRecordResponse(true, message, data);
     }
 }

--- a/src/main/java/org/project/timetracker/record/ActivityRecordService.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordService.java
@@ -3,20 +3,13 @@ package org.project.timetracker.record;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
-import java.time.format.TextStyle;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.project.timetracker.auth.TokenProcessor;
 import org.project.timetracker.auth.User;
 import org.project.timetracker.auth.UserRepository;
-import org.project.timetracker.record.data.ActivityRecordDayData;
-import org.project.timetracker.record.data.ActivityRecordEntry;
-import org.project.timetracker.record.data.ActivityRecordMonthData;
+import org.project.timetracker.record.data.ActivityRecordAllData;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -26,6 +19,7 @@ public class ActivityRecordService {
     private final ActivityRecordRepository activityRecordRepository;
     private final UserRepository userRepository;
     private final TokenProcessor tokenProcessor;
+    private final ActivityRecordDtoMapper activityRecordDtoMapper;
 
     public ActivityRecordResponse create(ActivityRecordCreateRequest request) {
         Long userId = tokenProcessor.parseToken(request.token());
@@ -47,7 +41,7 @@ public class ActivityRecordService {
 
         activityRecordRepository.save(newRecord);
 
-        return buildMonthlyResponse(userId, request.date().substring(0, 6), "일정이 성공적으로 추가되었습니다.");
+        return buildAllDataResponse(userId, "전체 데이터 조회 성공");
     }
 
     public ActivityRecordResponse deleteSchedule(ActivityRecordDeleteRequest request) {
@@ -57,46 +51,19 @@ public class ActivityRecordService {
         ActivityRecord recordToDelete = activityRecordRepository.findByUserIdAndStartTime(userId, startTime)
                 .orElseThrow(() -> new IllegalArgumentException("해당 시간대 일정이 없습니다."));
 
-        String yearMonth = recordToDelete.getStartTime().format(DateTimeFormatter.ofPattern("yyyyMM"));
         activityRecordRepository.delete(recordToDelete);
 
-        return buildMonthlyResponse(userId, yearMonth, "ok");
+        return buildAllDataResponse(userId, "전체 데이터 조회 성공");
     }
 
-    private ActivityRecordResponse buildMonthlyResponse(Long userId, String yearMonthStr, String message) {
-        YearMonth yearMonth = YearMonth.parse(yearMonthStr, DateTimeFormatter.ofPattern("yyyyMM"));
-        LocalDate startDate = yearMonth.atDay(1);
-        LocalDate endDate = yearMonth.atEndOfMonth();
+    private ActivityRecordResponse buildAllDataResponse(Long userId, String message) {
+        List<ActivityRecord> allRecords = activityRecordRepository.findByUserIdOrderByStartTimeAsc(userId);
 
-        List<ActivityRecord> records = activityRecordRepository.findByUserIdAndStartTimeBetweenOrderByStartTimeAsc(userId, startDate.atStartOfDay(), endDate.plusDays(1).atStartOfDay());
-        Map<LocalDate, List<ActivityRecord>> recordsByDate = records.stream()
-                .collect(Collectors.groupingBy(
-                        r -> r.getStartTime().toLocalDate()));
+        ActivityRecordAllData allData = activityRecordDtoMapper.mapToAllData(allRecords);
 
-        List<ActivityRecordDayData> days = recordsByDate.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey())
-                .map(entry -> {
-                    LocalDate date = entry.getKey();
-                    List<ActivityRecord> dailyRecords = entry.getValue();
-
-                    List<ActivityRecordEntry> entries = dailyRecords.stream()
-                            .map(r -> new ActivityRecordEntry(
-                                    r.getStartTime().toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm")),
-                                    r.getEndTime().toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm")),
-                                    r.getMemo()
-                            )).collect(Collectors.toList());
-
-                    return new ActivityRecordDayData(
-                            date.format(DateTimeFormatter.ISO_LOCAL_DATE),
-                            date.getDayOfMonth(),
-                            date.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN),
-                            entries
-                    );
-                }).collect(Collectors.toList());
-
-        ActivityRecordMonthData monthData = new ActivityRecordMonthData(yearMonthStr, days);
-        return ActivityRecordResponse.success(message, monthData);
+        return ActivityRecordResponse.success(message, allData);
     }
+
 
     private User findUserById(Long userId) {
         return userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));

--- a/src/main/java/org/project/timetracker/record/data/ActivityRecordAllData.java
+++ b/src/main/java/org/project/timetracker/record/data/ActivityRecordAllData.java
@@ -1,0 +1,8 @@
+package org.project.timetracker.record.data;
+
+import java.util.List;
+
+public record ActivityRecordAllData(
+        List<ActivityRecordMonthData> months
+) {
+}

--- a/src/main/java/org/project/timetracker/record/data/ActivityRecordDayData.java
+++ b/src/main/java/org/project/timetracker/record/data/ActivityRecordDayData.java
@@ -1,6 +1,10 @@
 package org.project.timetracker.record.data;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
 import java.util.List;
+import java.util.Locale;
 
 public record ActivityRecordDayData(
         String date,
@@ -8,5 +12,13 @@ public record ActivityRecordDayData(
         String weekday,
         List<ActivityRecordEntry> entries
 ) {
+    public static ActivityRecordDayData from(LocalDate date, List<ActivityRecordEntry> entries) {
+        return new ActivityRecordDayData(
+                date.format(DateTimeFormatter.ISO_LOCAL_DATE),
+                date.getDayOfMonth(),
+                date.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN),
+                entries
+        );
+    }
 
 }

--- a/src/main/java/org/project/timetracker/record/data/ActivityRecordEntry.java
+++ b/src/main/java/org/project/timetracker/record/data/ActivityRecordEntry.java
@@ -1,9 +1,23 @@
 package org.project.timetracker.record.data;
 
+import java.time.format.DateTimeFormatter;
+import org.project.timetracker.record.ActivityRecord;
+
 public record ActivityRecordEntry(
         String start,
         String end,
+        String category,
         String label
 ) {
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    public static ActivityRecordEntry from(ActivityRecord record) {
+        return new ActivityRecordEntry(
+                record.getStartTime().toLocalTime().format(TIME_FORMATTER),
+                record.getEndTime().toLocalTime().format(TIME_FORMATTER),
+                record.getCategory(),
+                record.getMemo()
+        );
+    }
 
 }

--- a/src/main/java/org/project/timetracker/record/data/ActivityRecordMonthData.java
+++ b/src/main/java/org/project/timetracker/record/data/ActivityRecordMonthData.java
@@ -1,10 +1,19 @@
 package org.project.timetracker.record.data;
 
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 public record ActivityRecordMonthData(
         String month,
         List<ActivityRecordDayData> days
 ) {
+    private static final DateTimeFormatter MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
 
+    public static ActivityRecordMonthData from(YearMonth yearMonth, List<ActivityRecordDayData> days) {
+        return new ActivityRecordMonthData(
+                yearMonth.format(MONTH_FORMATTER),
+                days
+        );
+    }
 }


### PR DESCRIPTION
### 주요 변경 사항
기존 `create`, `delete` API는 요청된 일정의 해당 월 데이터만 반환했으나, 프론트엔드 요청에 따라 해당 유저의 전체 활동 기록을 월별/일별로 그룹화하여 반환하도록 응답 형식을 변경했습니다.
### 상세 리팩토링 내용
1. DTO 변환 로직 분리
    - ActivityRecordService에 비대하게 존재하던 DTO 변환 로직(데이터 그룹화, 날짜 포매팅 등)을 별도의 ActivityRecordDtoMapper 컴포넌트로 분리
2. DTO의 책임 강화 
    - 단순 데이터 객체였던 ActivityRecordEntry, ActivityRecordDayData, ActivityRecordMonthData에 from 정적 팩토리 메서드를 추가