### PR TITLE
feat: 카테고리 없이 ai가 카테고리를 분류하여 기록을 등록하는 API 추가

### DIFF
--- a/src/main/java/org/project/timetracker/ai/AiCategoryService.java
+++ b/src/main/java/org/project/timetracker/ai/AiCategoryService.java
@@ -1,0 +1,39 @@
+package org.project.timetracker.ai;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatModel;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AiCategoryService {
+    private final VertexAiGeminiChatModel chatModel;
+
+    private static final List<String> CATEGORY_OPTIONS = List.of(
+            "생활", "일", "자기계발", "사교", "여가", "정신",  "기타"
+    );
+
+    private String createPrompt(String memo) {
+        String categoriesText = String.join(", ", CATEGORY_OPTIONS);
+
+        return String.format("""
+                너의 역할은 사용자의 활동 기록(메모)을 보고, 가장 적절한 카테고리 1개만 추천해서 분류하는 거야.
+                
+                [활동 메모]
+                %s
+
+                [카테고리 선택지]
+                %s
+
+                [지시]
+                - 활동 메모의 맥락을 분석해 줘.
+                - 카테고리 선택지 중에서 가장 적합한 단어 1개만 골라서 다른 설명 없이 단어만 응답해 줘.
+
+                [응답 예시]
+                자기계발
+                """,
+                memo,
+                categoriesText);
+    }
+}

--- a/src/main/java/org/project/timetracker/ai/AiCategoryService.java
+++ b/src/main/java/org/project/timetracker/ai/AiCategoryService.java
@@ -15,6 +15,10 @@ public class AiCategoryService {
     );
 
     public String recommendCategory(String memo) {
+        if (memo == null || memo.isBlank()) {
+            return "기타";
+        }
+
         String prompt = createPrompt(memo);
 
         String recommendedCategory = chatModel.call(prompt).trim();

--- a/src/main/java/org/project/timetracker/ai/AiCategoryService.java
+++ b/src/main/java/org/project/timetracker/ai/AiCategoryService.java
@@ -14,6 +14,14 @@ public class AiCategoryService {
             "생활", "일", "자기계발", "사교", "여가", "정신",  "기타"
     );
 
+    public String recommendCategory(String memo) {
+        String prompt = createPrompt(memo);
+
+        String recommendedCategory = chatModel.call(prompt).trim();
+
+        return ensureValidCategory(recommendedCategory);
+    }
+
     private String createPrompt(String memo) {
         String categoriesText = String.join(", ", CATEGORY_OPTIONS);
 
@@ -35,5 +43,13 @@ public class AiCategoryService {
                 """,
                 memo,
                 categoriesText);
+    }
+
+    private String ensureValidCategory(String recommendedCategory) {
+        if (CATEGORY_OPTIONS.contains(recommendedCategory)) {
+            return recommendedCategory;
+        }
+
+        return "기타";
     }
 }

--- a/src/main/java/org/project/timetracker/record/ActivityRecordController.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordController.java
@@ -1,6 +1,7 @@
 package org.project.timetracker.record;
 
 import lombok.RequiredArgsConstructor;
+import org.project.timetracker.ai.AiCategoryService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ActivityRecordController {
     private final ActivityRecordService activityRecordService;
+    private final AiCategoryService aiCategoryService;
 
     @PostMapping
     public ResponseEntity<ActivityRecordResponse> create(@RequestBody ActivityRecordCreateRequest request) {
@@ -27,7 +29,11 @@ public class ActivityRecordController {
     }
 
     @PostMapping("/ai-recommended")
-    public ResponseEntity<?> createWithAi(@RequestBody ActivityRecordCreateRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED).body("예시");
+    public ResponseEntity<ActivityRecordResponse> createWithAi(@RequestBody AiCreateRequest request) {
+        String recommendedCategory = aiCategoryService.recommendCategory(request.memo());
+
+        ActivityRecordCreateRequest recordCreateRequest = ActivityRecordCreateRequest.fromAiRequest(request, recommendedCategory);
+
+        return ResponseEntity.ok(activityRecordService.create(recordCreateRequest));
     }
 }

--- a/src/main/java/org/project/timetracker/record/ActivityRecordController.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordController.java
@@ -25,4 +25,9 @@ public class ActivityRecordController {
         ActivityRecordResponse response = activityRecordService.deleteSchedule(request);
         return ResponseEntity.ok(response);
     }
+
+    @PostMapping("/ai-recommended")
+    public ResponseEntity<?> createWithAi(@RequestBody ActivityRecordCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body("예시");
+    }
 }

--- a/src/main/java/org/project/timetracker/record/ActivityRecordCreateRequest.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordCreateRequest.java
@@ -8,4 +8,17 @@ public record ActivityRecordCreateRequest(
         String category,
         String memo
 ) {
+    public static ActivityRecordCreateRequest fromAiRequest(
+            AiCreateRequest aiRequest,
+            String category
+    ) {
+        return new ActivityRecordCreateRequest(
+                aiRequest.token(),
+                aiRequest.date(),
+                aiRequest.startTime(),
+                aiRequest.endTime(),
+                category,
+                aiRequest.memo()
+        );
+    }
 }

--- a/src/main/java/org/project/timetracker/record/AiCreateRequest.java
+++ b/src/main/java/org/project/timetracker/record/AiCreateRequest.java
@@ -1,0 +1,10 @@
+package org.project.timetracker.record;
+
+public record AiCreateRequest(
+        String token,
+        String date,
+        String startTime,
+        String endTime,
+        String memo
+) {
+}


### PR DESCRIPTION
## 구현 내용
### AI 기반 카테고리 자동 추천 기능 신설
`카테고리를 비워둔 채 기록 생성 요청이 올 경우 AI가 memo의 맥락을 분석하여 최적의 카테고리를 자동으로 추천하여 저장하는 기능을 구현`

1. AiCategoryService 추가
    - POST /api/records/ai-recommend 요청을 처리하기 위해 카테고리 추천 전용 AiCategoryService를 추가

    - AI 프롬프트 생성:
memo 내용과 사전에 정의된 CATEGORY_OPTIONS (예: "생활", "일", "자기계발"...) 리스트를 AI 프롬프트에 전달
AI에게 memo의 맥락을 분석하여 CATEGORY_OPTIONS 중 가장 적합한 1개의 단어만 반환하도록 지시

    - 방어 로직 및 유효성 검사:
memo가 null이거나 비어있으면 불필요한 AI API 호출을 막고 즉시 "기타" 카테고리를 반환
ensureValidCategory 메서드를 통해, AI가 CATEGORY_OPTIONS에 없는 응답(예: "공부입니다.")을 할 경우 '기타'로 변환하여 안정성을 확보

2. DTO 변환을 통한 서비스 로직 재활용
    - 신규 API 엔드포인트: 카테고리 없는 요청을 받기 위해 POST /api/records/ai-recommend 엔드포인트를 추가 및 전용 DTO인 AiCreateRequest를 추가
    - DTO 변환 및 로직 재활용:
컨트롤러에서 AiCategoryService를 호출하여 recommendedCategory를 받아옴
AiCreateRequest DTO와 recommendedCategory를 조합하여 기존 ActivityRecordCreateRequest DTO로 변환하는 정적 팩토리 메서드(fromAiRequest)를 구현