### PR TITLE
feat: 통계 기능의 응답에 세부적인 정보 추가

### DIFF
--- a/src/main/java/org/project/timetracker/statistic/StatisticsCalculator.java
+++ b/src/main/java/org/project/timetracker/statistic/StatisticsCalculator.java
@@ -29,4 +29,34 @@ public class StatisticsCalculator {
         }
         return results;
     }
-}
+
+    public Map<String, Map<String, StatisticsDetailData>> getStatisticsDetailsByName(List<ActivityRecord> activityRecords) {
+        Map<String, List<ActivityRecord>> groupByCategory = activityRecords.stream()
+                .collect(Collectors.groupingBy(ActivityRecord::getCategory));
+
+        Map<String, Map<String,StatisticsDetailData>> finalResults = new HashMap<>();
+
+
+        for (Map.Entry<String, List<ActivityRecord>> maps : groupByCategory.entrySet()) {
+            String category = maps.getKey();
+            List<ActivityRecord> records = maps.getValue();
+
+            Map<String, StatisticsDetailData> results = new HashMap<>();
+
+            Map<String, List<ActivityRecord>> groupByName = records.stream()
+                    .collect(Collectors.groupingBy(ActivityRecord::getMemo));
+
+            for (Map.Entry<String, List<ActivityRecord>> groupByNameMaps : groupByName.entrySet()) {
+                String name = groupByNameMaps.getKey();
+                List<ActivityRecord> values = maps.getValue();
+                int frequency = values.size();
+                long amount = records.stream().mapToLong(ActivityRecord::getSpanMinutes)
+                        .sum();
+
+                results.put(name, new StatisticsDetailData(frequency, amount));
+            }
+            finalResults.put(category, results);
+        }
+        return finalResults;
+    }
+    }

--- a/src/main/java/org/project/timetracker/statistic/StatisticsController.java
+++ b/src/main/java/org/project/timetracker/statistic/StatisticsController.java
@@ -7,7 +7,6 @@ import org.project.timetracker.auth.UserRepository;
 import org.project.timetracker.record.ActivityRecord;
 import org.project.timetracker.record.ActivityRecordRepository;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,10 +16,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -50,17 +47,23 @@ public class StatisticsController {
 
         Map<String, StatistcsData> miniResults = statisticsCalculator.getStatisticsByCategory(activityRecords);
 
+        Map<String, Map<String, StatisticsDetailData>> detailResults = statisticsCalculator.getStatisticsDetailsByName(activityRecords);
+
         long amountTotal = miniResults.values().stream()
                 .mapToLong(StatistcsData::getAmount)
                 .sum();
 
-        List<StatisticsDataResponse> dataResponse = getTotalStatistics(miniResults, amountTotal, timeTotal);
+        List<StatisticsDataResponse> dataResponse = getTotalStatistics(miniResults, detailResults, amountTotal, timeTotal);
 
-        return  ResponseEntity.ok(new StatisticsResponse(dataResponse));
+        return ResponseEntity.ok(new StatisticsResponse(dataResponse));
 
     }
 
-    private List<StatisticsDataResponse> getTotalStatistics(Map<String, StatistcsData> miniResults, long amountTotal, long timeTotal) {
+    private List<StatisticsDataResponse> getTotalStatistics(
+            Map<String, StatistcsData> miniResults,
+            Map<String, Map<String, StatisticsDetailData>> detailResults,
+            long amountTotal, long timeTotal
+    ) {
         List<StatisticsDataResponse> dataResponse = new ArrayList<>();
 
         for (Map.Entry<String, StatistcsData> miniResult : miniResults.entrySet()) {
@@ -69,18 +72,36 @@ public class StatisticsController {
 
             long amount = activityRecordValue.getAmount();
 
-            long hours = amount / 60;
-            long minutes = amount % 60;
-
-            String formattedAmount = String.format("%02d:%02d", hours, minutes);
+            String formattedAmount = getFormattedAmount(amount);
 
             long timePercent = Math.round((float) amount / amountTotal * 100);
             long accordPercent = Math.round((float) amount / timeTotal * 100);
 
+            Map<String, StatisticsDetailData> detailMaps = detailResults.get(category);
 
-            dataResponse.add(new StatisticsDataResponse(category, activityRecordValue.getFrequency(), formattedAmount, timePercent, accordPercent));
+            List<StatisticsDetailResponse> detailResponses = new ArrayList<>();
+
+            for (Map.Entry<String, StatisticsDetailData> details : detailMaps.entrySet()) {
+                String name = details.getKey();
+                StatisticsDetailData value = details.getValue();
+                String formattedDetailAmount = getFormattedAmount(value.getAmount());
+
+                detailResponses.add(new StatisticsDetailResponse(name, formattedDetailAmount, value.getFrequency()));
+            }
+
+            dataResponse.add(new StatisticsDataResponse(
+                    category, activityRecordValue.getFrequency(),
+                    formattedAmount, timePercent, accordPercent, detailResponses)
+            );
         }
         return dataResponse;
+    }
+
+    private String getFormattedAmount(long amount) {
+        long hours = amount / 60;
+        long minutes = amount % 60;
+
+        return String.format("%02d:%02d", hours, minutes);
     }
 }
 

--- a/src/main/java/org/project/timetracker/statistic/StatisticsDataResponse.java
+++ b/src/main/java/org/project/timetracker/statistic/StatisticsDataResponse.java
@@ -12,13 +12,17 @@ public class StatisticsDataResponse {
     private String amount;
     private double timePercent;
     private double accordPercent;
-    private List<StatisticsResponse> details;
+    private List<StatisticsDetailResponse> details;
 
-    public StatisticsDataResponse(String category, int frequency, String amount, double timePercent, double accordPercent) {
+    public StatisticsDataResponse(
+            String category, int frequency, String amount, double timePercent,
+            double accordPercent, List<StatisticsDetailResponse> details
+    ) {
         this.category = category;
         this.frequency = frequency;
         this.amount = amount;
         this.timePercent = timePercent;
         this.accordPercent = accordPercent;
+        this.details = details;
     }
 }

--- a/src/main/java/org/project/timetracker/statistic/StatisticsDataResponse.java
+++ b/src/main/java/org/project/timetracker/statistic/StatisticsDataResponse.java
@@ -2,6 +2,8 @@ package org.project.timetracker.statistic;
 
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 public class StatisticsDataResponse {
 
@@ -10,6 +12,7 @@ public class StatisticsDataResponse {
     private String amount;
     private double timePercent;
     private double accordPercent;
+    private List<StatisticsResponse> details;
 
     public StatisticsDataResponse(String category, int frequency, String amount, double timePercent, double accordPercent) {
         this.category = category;

--- a/src/main/java/org/project/timetracker/statistic/StatisticsDetailData.java
+++ b/src/main/java/org/project/timetracker/statistic/StatisticsDetailData.java
@@ -1,0 +1,21 @@
+package org.project.timetracker.statistic;
+
+public class StatisticsDetailData {
+
+    private int frequency;
+    private long amount;
+
+    public StatisticsDetailData(int frequency, long amount) {
+        this.frequency = frequency;
+        this.amount = amount;
+    }
+
+    public int getFrequency() {
+        return frequency;
+    }
+
+    public long getAmount() {
+        return amount;
+    }
+
+}

--- a/src/main/java/org/project/timetracker/statistic/StatisticsDetailResponse.java
+++ b/src/main/java/org/project/timetracker/statistic/StatisticsDetailResponse.java
@@ -11,5 +11,11 @@ public class StatisticsDetailResponse {
 
     private String name;
     private String amount;
-    private String frequency;
+    private int frequency;
+
+    public StatisticsDetailResponse(String name, String amount, int frequency) {
+        this.name = name;
+        this.amount = amount;
+        this.frequency = frequency;
+    }
 }

--- a/src/main/java/org/project/timetracker/statistic/StatisticsDetailResponse.java
+++ b/src/main/java/org/project/timetracker/statistic/StatisticsDetailResponse.java
@@ -1,0 +1,15 @@
+package org.project.timetracker.statistic;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+public class StatisticsDetailResponse {
+
+    private String name;
+    private String amount;
+    private String frequency;
+}


### PR DESCRIPTION
# 구현내용

- 기존에 존재했던 시간기록을 바탕으로 통계를 내는 기능에서 세부정보를 추가해주었습니다.
- 카테고리별로 시간기록을 group한 다음 다시 memo 내용을 바탕으로 group을 해주어서 빈도수, 총 시간 정보를 세분화하여 추가해주었습니다.