### PR TITLE
feat: 중복된 시간에 기록 추가 시 우선순위 기반으로 기록 분할해서 등록하는 기능 추가

### DIFF
--- a/src/main/java/org/project/timetracker/record/ActivityRecord.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecord.java
@@ -80,4 +80,20 @@ public class ActivityRecord {
         return span.toMinutes();
     }
 
+    public void updateTimeRange(LocalDateTime start, LocalDateTime end) {
+        this.startTime = start;
+        this.endTime = end;
+    }
+
+    public ActivityRecord copyWithNewTimeRange(LocalDateTime start, LocalDateTime end) {
+        return ActivityRecord.builder()
+                .user(this.user)
+                .startTime(start)
+                .endTime(end)
+                .category(this.category)
+                .memo(this.memo)
+                .source(this.source)
+                .build();
+    }
+
 }

--- a/src/main/java/org/project/timetracker/record/ActivityRecord.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecord.java
@@ -33,16 +33,33 @@ public class ActivityRecord {
 
     private String memo;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RecordSource source = RecordSource.USER; //default 설정
+
+
     @Builder
-    public ActivityRecord(User user, LocalDateTime startTime, LocalDateTime endTime, String category, String memo) {
+    public ActivityRecord(User user,
+            LocalDateTime startTime,
+            LocalDateTime endTime,
+            String category,
+            String memo,
+            RecordSource source) {
         this.user = user;
         this.startTime = startTime;
         this.endTime = endTime;
         this.category = category;
         this.memo = memo;
+        this.source = source != null ? source : RecordSource.USER;
     }
 
-    public static ActivityRecord create(User user, LocalDateTime startTime, LocalDateTime endTime, String category, String memo) {
+    public static ActivityRecord create(
+            User user,
+            LocalDateTime startTime,
+            LocalDateTime endTime,
+            String category,
+            String memo,
+            RecordSource source) {
         String memoToSave = memo;
         if (memoToSave == null) {
             memoToSave = "";
@@ -54,6 +71,7 @@ public class ActivityRecord {
                 .endTime(endTime)
                 .category(category)
                 .memo(memoToSave)
+                .source(source)
                 .build();
     }
 

--- a/src/main/java/org/project/timetracker/record/ActivityRecordCreateRequest.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordCreateRequest.java
@@ -6,7 +6,8 @@ public record ActivityRecordCreateRequest(
         String startTime,
         String endTime,
         String category,
-        String memo
+        String memo,
+        String source
 ) {
     public static ActivityRecordCreateRequest fromAiRequest(
             AiCreateRequest aiRequest,
@@ -18,7 +19,8 @@ public record ActivityRecordCreateRequest(
                 aiRequest.startTime(),
                 aiRequest.endTime(),
                 category,
-                aiRequest.memo()
+                aiRequest.memo(),
+                "USER" //카테고리 추천 ai 방식은 유저가 하는 것
         );
     }
 }

--- a/src/main/java/org/project/timetracker/record/ActivityRecordRepository.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordRepository.java
@@ -17,4 +17,12 @@ public interface ActivityRecordRepository extends JpaRepository<ActivityRecord, 
     List<ActivityRecord> findByUserIdAndBetweenTime(Long userId, LocalDateTime start, LocalDateTime end);
 
     List<ActivityRecord> findByUserIdOrderByStartTimeAsc(Long userId);
+
+    @Query("SELECT r FROM ActivityRecord r WHERE r.user.id = :userId " +
+            "AND r.startTime < :endTime AND r.endTime > :startTime " +
+            "ORDER BY r.startTime")
+    List<ActivityRecord> findOverlappingRecords(
+            @Param("userId") Long userId,
+            @Param("startTime") LocalDateTime startTime,
+            @Param("endTime") LocalDateTime endTime);
 }

--- a/src/main/java/org/project/timetracker/record/ActivityRecordService.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordService.java
@@ -11,8 +11,8 @@ import org.project.timetracker.auth.TokenProcessor;
 import org.project.timetracker.auth.User;
 import org.project.timetracker.auth.UserRepository;
 import org.project.timetracker.record.data.ActivityRecordAllData;
-import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +23,7 @@ public class ActivityRecordService {
     private final TokenProcessor tokenProcessor;
     private final ActivityRecordDtoMapper activityRecordDtoMapper;
 
+    @Transactional
     public ActivityRecordResponse create(ActivityRecordCreateRequest request) {
         Long userId = tokenProcessor.parseToken(request.token());
         User user = findUserById(userId);
@@ -31,7 +32,7 @@ public class ActivityRecordService {
         LocalDateTime endTime = parseDateTime(request.date(), request.endTime());
 
 
-        RecordSource source = request.source() != null ? RecordSource.valueOf(request.source()) : null;
+        RecordSource source = request.source() != null ? RecordSource.valueOf(request.source()) : RecordSource.USER;
 
         List<ActivityRecord> overlappingRecords = activityRecordRepository
                 .findOverlappingRecords(userId, startTime, endTime);
@@ -44,7 +45,7 @@ public class ActivityRecordService {
             activityRecordRepository.save(newRecord);
         } else {
             //우선순위 기반 처리 메서드
-            processWithPriority(user, newRecord, overlappingRecords);
+            processWithPriority(newRecord, overlappingRecords);
         }
 
         return buildAllDataResponse(userId, "전체 데이터 조회 성공");
@@ -80,24 +81,22 @@ public class ActivityRecordService {
                 LocalTime.parse(time, DateTimeFormatter.ofPattern("HH:mm")));
     }
 
-    private void processWithPriority(User user, ActivityRecord newRecord, List<ActivityRecord> overlappingRecords) {
+    private void processWithPriority(ActivityRecord newRecord, List<ActivityRecord> overlappingRecords) {
         int newPriority = newRecord.getSource().getPriority();
-
 
         List<ActivityRecord> toDelete = new ArrayList<>();//삭제
         List<ActivityRecord> toCreate = new ArrayList<>();//추가
-
-
-        LocalDateTime newStartTime = newRecord.getStartTime();
-        LocalDateTime newEndTime = newRecord.getEndTime();
 
         for (ActivityRecord existingRecord : overlappingRecords) {
             if (newPriority <= existingRecord.getSource().getPriority()) {
                 handleHigherPriorityConflict(newRecord, existingRecord, toDelete, toCreate);
             } else {
-                //낮은 우선순위 충돌 메서드
+                handleLowerPriorityConflict(newRecord, existingRecord, toCreate);
             }
         }
+
+        LocalDateTime newStartTime = newRecord.getStartTime();
+        LocalDateTime newEndTime = newRecord.getEndTime();
 
         //조정된 기록... 그런데 조정했는데 Start > End 면 저장 못함
         if (newStartTime.isBefore(newEndTime)) {
@@ -142,5 +141,41 @@ public class ActivityRecordService {
         } else if (newCutsExistingEnd) {
             existingRecord.updateTimeRange(existingStartTime, newStartTime);
         }
+    }
+
+    private void handleLowerPriorityConflict(
+            ActivityRecord newRecord,
+            ActivityRecord existingRecord,
+            List<ActivityRecord> toCreate
+    ) {
+        LocalDateTime newStartTime = newRecord.getStartTime();
+        LocalDateTime newEndTime = newRecord.getEndTime();
+        LocalDateTime existingStartTime = existingRecord.getStartTime();
+        LocalDateTime existingEndTime = existingRecord.getEndTime();
+
+        boolean existingCoversNew = !existingStartTime.isAfter(newStartTime)
+                && !existingEndTime.isBefore(newEndTime);
+        boolean existingInsideNew =
+                existingStartTime.isAfter(newStartTime) && existingEndTime.isBefore(newEndTime);
+        boolean existingCutsNewStart = !existingStartTime.isAfter(newStartTime) &&
+                existingEndTime.isAfter(newStartTime) &&
+                existingEndTime.isBefore(newEndTime);
+        boolean existingCutsNewEnd =
+                existingStartTime.isAfter(newStartTime) &&
+                        existingStartTime.isBefore(newEndTime) &&
+                        !existingEndTime.isBefore(newEndTime);
+
+        if (existingCoversNew) {
+            newRecord.updateTimeRange(newStartTime, newStartTime);
+        } else if (existingInsideNew) {
+            toCreate.add(newRecord.copyWithNewTimeRange(newStartTime, existingStartTime));
+
+            newRecord.updateTimeRange(existingEndTime, newEndTime);
+        } else if (existingCutsNewStart) {
+            newRecord.updateTimeRange(existingEndTime, newEndTime);
+        } else if (existingCutsNewEnd) {
+            newRecord.updateTimeRange(newStartTime, existingStartTime);
+        }
+
     }
 }

--- a/src/main/java/org/project/timetracker/record/ActivityRecordService.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordService.java
@@ -32,12 +32,15 @@ public class ActivityRecordService {
             throw new IllegalArgumentException("이미 해당 시간대에 일정이 존재합니다.");
         }
 
+        RecordSource source = request.source() != null ? RecordSource.valueOf(request.source()) : null;
+
         ActivityRecord newRecord = ActivityRecord.create(
                 user,
                 startTime,
                 endTime,
                 request.category(),
-                request.memo());
+                request.memo(),
+                source);
 
         activityRecordRepository.save(newRecord);
 

--- a/src/main/java/org/project/timetracker/record/ActivityRecordService.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordService.java
@@ -4,12 +4,14 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.project.timetracker.auth.TokenProcessor;
 import org.project.timetracker.auth.User;
 import org.project.timetracker.auth.UserRepository;
 import org.project.timetracker.record.data.ActivityRecordAllData;
+import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -34,13 +36,15 @@ public class ActivityRecordService {
         List<ActivityRecord> overlappingRecords = activityRecordRepository
                 .findOverlappingRecords(userId, startTime, endTime);
 
+        ActivityRecord newRecord = ActivityRecord.create(
+                user, startTime, endTime, request.category(), request.memo(), source
+        );
+
         if (overlappingRecords.isEmpty()) {
-            ActivityRecord newRecord = ActivityRecord.create(
-                    user, startTime, endTime, request.category(), request.memo(), source
-            );
             activityRecordRepository.save(newRecord);
         } else {
             //우선순위 기반 처리 메서드
+            processWithPriority(user, newRecord, overlappingRecords);
         }
 
         return buildAllDataResponse(userId, "전체 데이터 조회 성공");
@@ -74,5 +78,34 @@ public class ActivityRecordService {
     private LocalDateTime parseDateTime(String date, String time) {
         return LocalDateTime.of(LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyyMMdd")),
                 LocalTime.parse(time, DateTimeFormatter.ofPattern("HH:mm")));
+    }
+
+    private void processWithPriority(User user, ActivityRecord newRecord, List<ActivityRecord> overlappingRecords) {
+        int newPriority = newRecord.getSource().getPriority();
+
+
+        List<ActivityRecord> toDelete = new ArrayList<>();//삭제
+        List<ActivityRecord> toCreate = new ArrayList<>();//추가
+
+
+        LocalDateTime newStartTime = newRecord.getStartTime();
+        LocalDateTime newEndTime = newRecord.getEndTime();
+
+        for (ActivityRecord existingRecord : overlappingRecords) {
+            if (newPriority <= existingRecord.getSource().getPriority()) {
+                //높은 우선순위 충돌 메서드
+            } else {
+                //낮은 우선순위 충돌 메서드
+            }
+        }
+
+        //조정된 기록... 그런데 조정했는데 Start > End 면 저장 못함
+        if (newStartTime.isBefore(newEndTime)) {
+            toCreate.add(newRecord);
+        }
+
+        activityRecordRepository.deleteAll(toDelete);
+        //시간 변경 -> JPA dirty checking update
+        activityRecordRepository.saveAll(toCreate);
     }
 }

--- a/src/main/java/org/project/timetracker/record/ActivityRecordService.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordService.java
@@ -28,21 +28,20 @@ public class ActivityRecordService {
         LocalDateTime startTime = parseDateTime(request.date(), request.startTime());
         LocalDateTime endTime = parseDateTime(request.date(), request.endTime());
 
-        if (activityRecordRepository.existsOverlappingRecords(userId, startTime, endTime)) {
-            throw new IllegalArgumentException("이미 해당 시간대에 일정이 존재합니다.");
-        }
 
         RecordSource source = request.source() != null ? RecordSource.valueOf(request.source()) : null;
 
-        ActivityRecord newRecord = ActivityRecord.create(
-                user,
-                startTime,
-                endTime,
-                request.category(),
-                request.memo(),
-                source);
+        List<ActivityRecord> overlappingRecords = activityRecordRepository
+                .findOverlappingRecords(userId, startTime, endTime);
 
-        activityRecordRepository.save(newRecord);
+        if (overlappingRecords.isEmpty()) {
+            ActivityRecord newRecord = ActivityRecord.create(
+                    user, startTime, endTime, request.category(), request.memo(), source
+            );
+            activityRecordRepository.save(newRecord);
+        } else {
+            //우선순위 기반 처리 메서드
+        }
 
         return buildAllDataResponse(userId, "전체 데이터 조회 성공");
     }

--- a/src/main/java/org/project/timetracker/record/ActivityRecordService.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecordService.java
@@ -93,7 +93,7 @@ public class ActivityRecordService {
 
         for (ActivityRecord existingRecord : overlappingRecords) {
             if (newPriority <= existingRecord.getSource().getPriority()) {
-                //높은 우선순위 충돌 메서드
+                handleHigherPriorityConflict(newRecord, existingRecord, toDelete, toCreate);
             } else {
                 //낮은 우선순위 충돌 메서드
             }
@@ -107,5 +107,40 @@ public class ActivityRecordService {
         activityRecordRepository.deleteAll(toDelete);
         //시간 변경 -> JPA dirty checking update
         activityRecordRepository.saveAll(toCreate);
+    }
+
+    private void handleHigherPriorityConflict(
+            ActivityRecord newRecord,
+            ActivityRecord existingRecord,
+            List<ActivityRecord> toDelete,
+            List<ActivityRecord> toCreate) {
+        LocalDateTime newStartTime = newRecord.getStartTime();
+        LocalDateTime newEndTime = newRecord.getEndTime();
+        LocalDateTime existingStartTime = existingRecord.getStartTime();
+        LocalDateTime existingEndTime = existingRecord.getEndTime();
+
+        boolean newCoversExisting = !newStartTime.isAfter(existingStartTime)
+                && !newEndTime.isBefore(existingEndTime);
+        boolean newInsideExisting = newStartTime.isAfter(existingStartTime)
+                && newEndTime.isBefore(existingEndTime);
+        boolean newCutsExistingStart = !newStartTime.isAfter(existingStartTime) &&
+                newEndTime.isAfter(existingStartTime) &&
+                newEndTime.isBefore(existingEndTime);
+        boolean newCutsExistingEnd = newStartTime.isAfter(existingStartTime) &&
+                newStartTime.isBefore(existingEndTime) &&
+                !newEndTime.isBefore(existingEndTime);
+
+        if (newCoversExisting) {
+            toDelete.add(existingRecord);
+        } else if (newInsideExisting) {
+            existingRecord.updateTimeRange(existingStartTime, newStartTime);
+
+            ActivityRecord secondPart = existingRecord.copyWithNewTimeRange(newEndTime, existingEndTime);
+            toCreate.add(secondPart);
+        } else if (newCutsExistingStart) {
+            existingRecord.updateTimeRange(newEndTime, existingEndTime);
+        } else if (newCutsExistingEnd) {
+            existingRecord.updateTimeRange(existingStartTime, newStartTime);
+        }
     }
 }

--- a/src/main/java/org/project/timetracker/record/RecordSource.java
+++ b/src/main/java/org/project/timetracker/record/RecordSource.java
@@ -1,0 +1,17 @@
+package org.project.timetracker.record;
+
+public enum RecordSource {
+    USER(1),
+    GPS(2),
+    CALENDAR(3);
+
+    private final int priority;
+
+    RecordSource(int priority) {
+        this.priority = priority;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+}

--- a/src/main/java/org/project/timetracker/voice/AiVoiceController.java
+++ b/src/main/java/org/project/timetracker/voice/AiVoiceController.java
@@ -46,7 +46,8 @@ public class AiVoiceController {
                 info[1],
                 info[2],
                 category,
-                info[3]
+                info[3],
+                "USER"
         );
 
         ActivityRecordResponse response = activityRecordService.create(newRequest);


### PR DESCRIPTION
## 주요 변경 사항
1. RecordSource(Enum) 추가
  - ActivityRecord에 RecordSource 필드 추가

2. 겹치는 기록 조회 기능 추가
  - 지정된 시간대와 겹치는 ActivityRecord 리스트 반환 쿼리 메서드 추가

3. 우선순위 기반 시간 충돌 처리 구현
  - processWithPriority() 추가
  - 새 기록이 더 높거나 같은 우선순위 → 기존 기록 조정/분할/삭제
  - 새 기록이 더 낮은 우선순위 → 새 기록 시간 조정/분할/삭제
  - create()에 `@Transactional` 적용하여 시간 조정(update), 삭제, 생성 로직을 하나의 트랜잭션에서 처리
