### PR TITLE
fix: 통계 계산 로직 오류 수정 및 데이터 무결성 강화

### DIFF
--- a/src/main/java/org/project/timetracker/record/ActivityRecord.java
+++ b/src/main/java/org/project/timetracker/record/ActivityRecord.java
@@ -76,6 +76,9 @@ public class ActivityRecord {
     }
 
     public long getSpanMinutes() {
+        if (endTime.isBefore(startTime)) {
+            return 0;
+        }
         Duration span = Duration.between(startTime, endTime);
         return span.toMinutes();
     }

--- a/src/main/java/org/project/timetracker/statistic/StatisticsCalculator.java
+++ b/src/main/java/org/project/timetracker/statistic/StatisticsCalculator.java
@@ -48,9 +48,9 @@ public class StatisticsCalculator {
 
             for (Map.Entry<String, List<ActivityRecord>> groupByNameMaps : groupByName.entrySet()) {
                 String name = groupByNameMaps.getKey();
-                List<ActivityRecord> values = maps.getValue();
+                List<ActivityRecord> values = groupByNameMaps.getValue();
                 int frequency = values.size();
-                long amount = records.stream().mapToLong(ActivityRecord::getSpanMinutes)
+                long amount = values.stream().mapToLong(ActivityRecord::getSpanMinutes)
                         .sum();
 
                 results.put(name, new StatisticsDetailData(frequency, amount));
@@ -59,4 +59,4 @@ public class StatisticsCalculator {
         }
         return finalResults;
     }
-    }
+}

--- a/src/main/java/org/project/timetracker/statistic/StatisticsController.java
+++ b/src/main/java/org/project/timetracker/statistic/StatisticsController.java
@@ -75,8 +75,8 @@ public class StatisticsController {
 
             String formattedAmount = getFormattedAmount(amount);
 
-            long timePercent = Math.round((float) amount / amountTotal * 100);
-            long accordPercent = Math.round((float) amount / timeTotal * 100);
+            long timePercent = calculatePercent(amount, amountTotal);
+            long accordPercent = calculatePercent(amount, timeTotal);
 
             Map<String, StatisticsDetailData> detailMaps = detailResults.get(category);
 
@@ -147,7 +147,7 @@ public class StatisticsController {
         for (Map.Entry<String, StatistcsData> entry : statisticsByCategory.entrySet()) {
             String category = entry.getKey();
             long amount = entry.getValue().getAmount();
-            double percent = Math.round((float) amount / totalMinutes * 100);
+            double percent = calculatePercent(amount, totalMinutes);
             categoryData.add(new CategoryData(category, (int) amount, percent));
         }
         return categoryData;
@@ -189,6 +189,12 @@ public class StatisticsController {
         return ResponseEntity.ok(new ComparingResponse(true, userTimeData));
     }
 
+    private long calculatePercent(long numerator, long denominator) {
+        if (denominator == 0) {
+            return 0;
+        }
+        return Math.round((float) numerator / denominator * 100);
+    }
 }
 
 


### PR DESCRIPTION
[상세 내용]
1. StatisticsCalculator 로직 버그 수정
   - getStatisticsDetailsByName 메서드에서 세부 항목(Memo) 통계 산출 시, 해당 항목이 아닌 카테고리 전체 합계가 반환되는 오류 수정
   - 변수 참조 실수 수정 (records -> values)

2. StatisticsController 강화
   - 통계 퍼센트 계산 시 분모가 0일 경우(데이터 없음 등)를 대비한 안전한 계산 메서드(calculatePercent) 추가.
   - 0으로 나누기 연산 시 발생할 수 있는 Infinity/NaN 값 방지.

3. ActivityRecord 데이터 방어 로직 추가
   - 종료 시간이 시작 시간보다 빠를 경우(음수 시간) 0을 반환하도록 getSpanMinutes 메서드 개선.

추가적으로 start_date > end_date 인 데이터들 모두 지웠습니다!

로직에 변수 참조 잘못되어 있는 것도 함께 고쳤는데 제가 의도를 잘 이해 못하고 잘못 고친 걸 수도 있어서 한 번 확인해주시면 감사하겠습니다